### PR TITLE
Change version req

### DIFF
--- a/ads_common/google-ads-common.gemspec
+++ b/ads_common/google-ads-common.gemspec
@@ -34,9 +34,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.files = Dir.glob('{lib,test}/**/*') + %w(COPYING README.md ChangeLog)
   s.test_files = Dir.glob('test/test_*.rb')
-  #s.add_runtime_dependency('savon', '~> 1.2.0')
   s.add_runtime_dependency('google-ads-savon')
-  #s.add_runtime_dependency('httpi', '~> 1.1.0')
   s.add_runtime_dependency('httpi', '>= 1.1.0')
   s.add_runtime_dependency('signet', '~> 0.6.0')
   s.add_development_dependency('rake', '>= 10.4.2')

--- a/ads_common/google-ads-common.gemspec
+++ b/ads_common/google-ads-common.gemspec
@@ -34,8 +34,10 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.files = Dir.glob('{lib,test}/**/*') + %w(COPYING README.md ChangeLog)
   s.test_files = Dir.glob('test/test_*.rb')
-  s.add_runtime_dependency('savon', '~> 1.2.0')
-  s.add_runtime_dependency('httpi', '~> 1.1.0')
+  #s.add_runtime_dependency('savon', '~> 1.2.0')
+  s.add_runtime_dependency('google-ads-savon')
+  #s.add_runtime_dependency('httpi', '~> 1.1.0')
+  s.add_runtime_dependency('httpi', '>= 1.1.0')
   s.add_runtime_dependency('signet', '~> 0.6.0')
   s.add_development_dependency('rake', '>= 10.4.2')
 end

--- a/ads_savon/google-ads-savon.gemspec
+++ b/ads_savon/google-ads-savon.gemspec
@@ -16,14 +16,10 @@ Gem::Specification.new do |s|
   s.rubyforge_project = s.name
   s.license = 'MIT'
 
-  #s.add_dependency "nori",     "~> 2.4"
   s.add_dependency "nori",     "~> 2.1"
-  #s.add_dependency "httpi",    "~> 2.3"
   s.add_dependency "httpi",    ">= 1.1.0"
-  #s.add_dependency "wasabi",   "~> 3.4"
   s.add_dependency "wasabi",   "~> 3.1"
   s.add_dependency "akami",    "~> 1.2"
-  #s.add_dependency "gyoku",    "~> 1.2"
   s.add_dependency "gyoku",    "~> 1.0"
 
   s.add_dependency "builder",  ">= 2.1.2"

--- a/ads_savon/google-ads-savon.gemspec
+++ b/ads_savon/google-ads-savon.gemspec
@@ -16,11 +16,15 @@ Gem::Specification.new do |s|
   s.rubyforge_project = s.name
   s.license = 'MIT'
 
-  s.add_dependency "nori",     "~> 2.4"
-  s.add_dependency "httpi",    "~> 2.3"
-  s.add_dependency "wasabi",   "~> 3.4"
+  #s.add_dependency "nori",     "~> 2.4"
+  s.add_dependency "nori",     "~> 2.1"
+  #s.add_dependency "httpi",    "~> 2.3"
+  s.add_dependency "httpi",    ">= 1.1.0"
+  #s.add_dependency "wasabi",   "~> 3.4"
+  s.add_dependency "wasabi",   "~> 3.1"
   s.add_dependency "akami",    "~> 1.2"
-  s.add_dependency "gyoku",    "~> 1.2"
+  #s.add_dependency "gyoku",    "~> 1.2"
+  s.add_dependency "gyoku",    "~> 1.0"
 
   s.add_dependency "builder",  ">= 2.1.2"
   s.add_dependency "nokogiri", ">= 1.4.0"

--- a/adwords_api/google-adwords-api.gemspec
+++ b/adwords_api/google-adwords-api.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |s|
   s.files = Dir.glob('{lib,test}/**/*') + Dir.glob('examples/v*/**/*') +
       %w(COPYING README.md ChangeLog adwords_api.yml)
   s.test_files = ['test/suite_unittests.rb']
-  #s.add_runtime_dependency('google-ads-common', '~> 0.10.1')
   s.add_runtime_dependency('google-ads-common')
   s.add_development_dependency('rr', '~> 1.1.2')
   s.add_development_dependency('webmock', '~> 1.21.0')

--- a/adwords_api/google-adwords-api.gemspec
+++ b/adwords_api/google-adwords-api.gemspec
@@ -35,7 +35,8 @@ Gem::Specification.new do |s|
   s.files = Dir.glob('{lib,test}/**/*') + Dir.glob('examples/v*/**/*') +
       %w(COPYING README.md ChangeLog adwords_api.yml)
   s.test_files = ['test/suite_unittests.rb']
-  s.add_runtime_dependency('google-ads-common', '~> 0.10.1')
+  #s.add_runtime_dependency('google-ads-common', '~> 0.10.1')
+  s.add_runtime_dependency('google-ads-common')
   s.add_development_dependency('rr', '~> 1.1.2')
   s.add_development_dependency('webmock', '~> 1.21.0')
 end


### PR DESCRIPTION
pointing gemspec to use `google-ads-savon` (fork of `savon` 1.2.0) since other longboat libraries require `savon` 2.x, the stable version now for some time. 

This repo includes this forked version of savon because it has a strong reliance on 1.x API and couldn't be upgrades to 2.x API easily. The only difference between `google-ads-savon` and `savon` 1.2.0 is the gemspec. `google-ads-savon` bumped the versions of several of the gems. I changed them to comply to longboat. 
